### PR TITLE
Use /var/lib instead of /opt

### DIFF
--- a/conf/gmpwidevine.sh
+++ b/conf/gmpwidevine.sh
@@ -1,2 +1,2 @@
-MOZ_GMP_PATH="$MOZ_GMP_PATH${MOZ_GMP_PATH:+:}/opt/widevine/gmp-widevinecdm/system-installed"
+MOZ_GMP_PATH="$MOZ_GMP_PATH${MOZ_GMP_PATH:+:}/var/lib/widevine/gmp-widevinecdm/system-installed"
 export MOZ_GMP_PATH

--- a/widevine-installer
+++ b/widevine-installer
@@ -10,9 +10,9 @@ set -e
 : ${LIBDIR:=/usr/lib64}
 : ${BINDIR:=/usr/bin}
 : ${LIBEXECDIR:=/usr/libexec}
-: ${OPTDIR:=/opt}
+: ${STATEDIR:=/var/lib}
 : ${SCRIPT_BASE:=$LIBEXECDIR/widevine-installer}
-: ${INSTALL_BASE:=$OPTDIR/widevine}
+: ${INSTALL_BASE:=$STATEDIR/widevine}
 : ${DISTFILES_BASE:=https://commondatastorage.googleapis.com/chromeos-localmirror/distfiles}
 : ${LACROS_NAME:=chromeos-lacros-arm64-squash-zstd}
 : ${LACROS_VERSION:=120.0.6098.0}


### PR DESCRIPTION
Fedora (and other distros) don't allow packages to write to `/opt`, let's use `/var/lib` instead.