### PR TITLE
Update widevine-installer for Debian

### DIFF
--- a/widevine-installer
+++ b/widevine-installer
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # SPDX-License-Identifier: MIT
 
 set -e


### PR DESCRIPTION
This script has some bashisms, so it needs bash to run. Debian aliases /bin/sh to dash so it can't run it as-is.